### PR TITLE
docs: Updated wrong link (#3)

### DIFF
--- a/content/docs/contributing/how-to-contribute.md
+++ b/content/docs/contributing/how-to-contribute.md
@@ -27,7 +27,7 @@ top = false
 ### Create an issue
 
 - [Bug report](https://github.com/thlorenz/rid/issues/new)
-- [Feature request](https://github.com/aaranxu/rid/issues/new)
+- [Feature request](https://github.com/thlorenz/rid/issues/new)
 
 ## Improve documentation
 


### PR DESCRIPTION
Fixed a link that was pointing to a non-existent repository.

Closes #3 